### PR TITLE
Removes rename.yml after first commit

### DIFF
--- a/.github/workflows/rename.yml
+++ b/.github/workflows/rename.yml
@@ -16,9 +16,18 @@ jobs:
         shell: bash
       - run: echo "REPOSITORY_OWNER=$(echo '${{ github.repository }}' | awk -F '/' '{print $1}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
         shell: bash
-      - run: |
+      - name: Rename the project
+        run: |
           echo "Using '${{ env.REPOSITORY_NAME }}' and "${{ env.REPOSITORY_OWNER }}" to rename fpm package"
           sed -i -e 's/<user_name>/${{ env.REPOSITORY_OWNER }}/g' -e 's/<repo_name>/${{ env.REPOSITORY_NAME }}/g' FPM.ftd
+      - name: Remove File
+        uses: JesseTG/rm@v1.0.3
+        with:
+            path: .github/workflows/rename.yml
+      - name: Get last commit message
+        id: last-commit-message
+        run: |
+          echo "::set-output name=msg::$(git log -1 --pretty=%s)"
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "✅ Ready to clone and code."

--- a/.github/workflows/rename.yml
+++ b/.github/workflows/rename.yml
@@ -24,10 +24,6 @@ jobs:
         uses: JesseTG/rm@v1.0.3
         with:
             path: .github/workflows/rename.yml
-      - name: Get last commit message
-        id: last-commit-message
-        run: |
-          echo "::set-output name=msg::$(git log -1 --pretty=%s)"
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "✅ Ready to clone and code."

--- a/.github/workflows/rename.yml
+++ b/.github/workflows/rename.yml
@@ -20,10 +20,7 @@ jobs:
         run: |
           echo "Using '${{ env.REPOSITORY_NAME }}' and "${{ env.REPOSITORY_OWNER }}" to rename fpm package"
           sed -i -e 's/<user_name>/${{ env.REPOSITORY_OWNER }}/g' -e 's/<repo_name>/${{ env.REPOSITORY_NAME }}/g' FPM.ftd
-      - name: Remove File
-        uses: JesseTG/rm@v1.0.3
-        with:
-            path: .github/workflows/rename.yml
+          rm .github/workflows/rename.yml
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "✅ Ready to clone and code."


### PR DESCRIPTION
1. Used the original repo as template in my personal repo
2. used the personal repo with modified "rename.yml" file as template for another repo.
3. the "remove file" uses "io.rmRF", supports only one relative/absolute path.
4. The "rename.yml" gets deleted after first commit.

![image](https://user-images.githubusercontent.com/106665143/178688085-c1ccabe7-5de5-489f-8d2a-248ac35ad078.png)

